### PR TITLE
Add latest eslint to dev dependencies and fix rules

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -2,11 +2,11 @@ env:
   node: true
 
 rules:
-  indent: [2, 2]
-  quotes: [2, "single"]
-  no-spaced-func: [2, "never"]
-  space-before-function-paren: [2, "never"]
-  valid-jsdoc: [2, { "prefer": { "return": "returns" }}]
-  space-after-keywords: [2, "always"]
-  space-before-blocks: [2, "always"]
-  space-in-parens: [2, "never"]
+  indent: ["error", 2]
+  quotes: ["error", "single"]
+  func-call-spacing: ["error", "never"]
+  space-before-function-paren: ["error", "never"]
+  valid-jsdoc: ["error", { "prefer": { "return": "returns" }}]
+  keyword-spacing: ["error"]
+  space-before-blocks: ["error", "always"]
+  space-in-parens: ["error", "never"]

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "devDependencies": {
     "chai": "^3.5.0",
     "coveralls": "^2.11.8",
+    "eslint": "^3.8.1",
     "istanbul": "^0.4.2",
     "mocha": "^2.4.5"
   }


### PR DESCRIPTION
Rules are changed so that everything working with latest (3.8.1) eslint.
