### PR TITLE
Catch errors reading package.json file

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -1,7 +1,14 @@
 var fs = require('fs');
 
 function loadConfig() {
-  return fs.readFileSync('package.json');
+  try {
+    return fs.readFileSync('package.json');
+  } catch (e) {
+    console.warn('Unable to load config from package.json');
+    // Return the string representation of an empty JSON object,
+    // as it will be parsed outside of this method
+    return '{}';
+  }
 }
 
 module.exports.loadConfig = loadConfig;


### PR DESCRIPTION
The package.json file may not necessarily exist in the same directory as where eslint or gulp-eslint is run from.

For example, in our case we share node modules between multiple folders as below:
```
- package.json
- subfolder
  |- gulpfile.js
- subfolder
  |- gulpfile.js
```

This fix simply wraps the package.json read in a try/catch as it suits our purposes, however a more thorough fix would be to traverse parent directories until a package.json is found, like node does to resolve the node_modules directory.