### PR TITLE
Remove unneeded node_modules path from npm scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ more info on setting up a linting task.
 The simplest way to run eslint-teamcity is from an npm script in a build step. You could setup a script similar to this:
 ```json
 "scripts": {
-  "lint:teamcity": "node node_modules/.bin/eslint app/src -f './node_modules/eslint-teamcity/index.js'"
+  "lint:teamcity": "eslint app/src --format './node_modules/eslint-teamcity/index.js'"
 }
 ```
 

--- a/package.json
+++ b/package.json
@@ -4,11 +4,11 @@
   "description": "An ESLint formatter plugin for TeamCity",
   "main": "index.js",
   "scripts": {
-    "lint": "./node_modules/.bin/eslint .",
+    "lint": "eslint .",
     "precommit": "lint-staged",
-    "prettier": "./node_modules/.bin/prettier --write",
-    "test": "./node_modules/mocha/bin/mocha \"./test/**/*.spec.js\"",
-    "test-travis": "./node_modules/istanbul/lib/cli.js cover ./node_modules/mocha/bin/_mocha -- -R spec \"./test/**/*.spec.js\""
+    "prettier": "prettier --write",
+    "test": "mocha \"./test/**/*.spec.js\"",
+    "test-travis": "istanbul cover ./node_modules/mocha/bin/_mocha -- -R spec \"./test/**/*.spec.js\""
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Hi there, 
I've replaced full paths in npm scripts with just binary names since npm adds local .bin directory to the path available to the scripts. This behaviour is described in the documentation https://docs.npmjs.com/cli/run-script 

Tested all scripts locally and haven't noticed any changes. 
I also made a similar change in readme file. In addition replaced -f with much more explicit --force