### PR TITLE
Use relative paths

### DIFF
--- a/src/formatters/errors.js
+++ b/src/formatters/errors.js
@@ -1,3 +1,4 @@
+const path = require('path');
 const utils = require('../utils');
 
 /**
@@ -21,7 +22,7 @@ module.exports = (results, config) => {
       return;
     }
 
-    const filePath = utils.escapeTeamCityString(result.filePath);
+    const filePath = utils.escapeTeamCityString(path.relative(process.cwd(), result.filePath));
 
     outputList.push(`##teamcity[testStarted name='${reportName}: ${filePath}']`);
 

--- a/src/formatters/inspections.js
+++ b/src/formatters/inspections.js
@@ -1,3 +1,4 @@
+const path = require('path');
 const utils = require('../utils');
 
 /**
@@ -19,7 +20,7 @@ module.exports = (results, config) => {
       return;
     }
 
-    const filePath = utils.escapeTeamCityString(result.filePath);
+    const filePath = utils.escapeTeamCityString(path.relative(process.cwd(), result.filePath));
 
     messages.forEach(messageObj => {
       const { line, column, message, ruleId, fatal, severity } = messageObj;


### PR DESCRIPTION
Currently this reporter uses absolute paths which lead to quite a lot of noise. This PR uses `path.relative` to should file paths relative to current working directory (typically the project root).

**Before:**
![image](https://user-images.githubusercontent.com/636753/45040128-2e4c4e80-b05d-11e8-886f-41ccfed000a3.png)

**After:**
![image](https://user-images.githubusercontent.com/636753/45040227-6c497280-b05d-11e8-8ab2-24c4d84ce0bf.png)
