### PR TITLE
Ensure slash-separated paths in the inspections reporter

### DIFF
--- a/src/formatters/errors.js
+++ b/src/formatters/errors.js
@@ -22,7 +22,8 @@ module.exports = (results, config) => {
       return;
     }
 
-    const filePath = utils.escapeTeamCityString(path.relative(process.cwd(), result.filePath));
+    const relativeFilePath = path.relative(process.cwd(), result.filePath);
+    const filePath = utils.escapeTeamCityString(relativeFilePath.replace(/\\/g, '/')); // Ensure slashes on Windows
 
     outputList.push(`##teamcity[testStarted name='${reportName}: ${filePath}']`);
 

--- a/src/formatters/inspections.js
+++ b/src/formatters/inspections.js
@@ -20,7 +20,8 @@ module.exports = (results, config) => {
       return;
     }
 
-    const filePath = utils.escapeTeamCityString(path.relative(process.cwd(), result.filePath));
+    const relativeFilePath = path.relative(process.cwd(), result.filePath);
+    const filePath = utils.escapeTeamCityString(relativeFilePath.replace(/\\/g, '/')); // Ensure slashes on Windows
 
     messages.forEach(messageObj => {
       const { line, column, message, ruleId, fatal, severity } = messageObj;

--- a/test/formatters/errors.spec.js
+++ b/test/formatters/errors.spec.js
@@ -83,6 +83,23 @@ describe('error formatting', function() {
     });
   });
 
+  describe('output with directory paths', function() {
+    beforeEach(function() {
+      results.push({ ...createFatalError(), filePath: 'path\\with\\backslash\\file.js' });
+    });
+
+    it('should render slashes in the service messages', function() {
+      const outputList = formatErrors(results, reportConfig);
+
+      expect(outputList[1]).to.eql(
+        "##teamcity[testStarted name='ESLint Violations: path/with/backslash/file.js']"
+      );
+      expect(outputList[2]).to.eql(
+        "##teamcity[testFailed name='ESLint Violations: path/with/backslash/file.js' message='line 1, col 1, Some fatal error (no-eval)']"
+      );
+    });
+  });
+
   describe('warning output', function() {
     beforeEach(function() {
       results.push(createDummyWarning());

--- a/test/formatters/inspections.spec.js
+++ b/test/formatters/inspections.spec.js
@@ -67,6 +67,20 @@ describe('inspection formatting', function() {
     });
   });
 
+  describe('output with directory paths', function() {
+    beforeEach(function() {
+      results.push({ ...createFatalError(), filePath: 'path\\with\\backslash\\file.js' });
+    });
+
+    it('should render slashes in the service messages', function() {
+      const outputList = formatInspections(results, reportConfig);
+
+      expect(outputList[1]).to.eql(
+        "##teamcity[inspection typeId='no-eval' message='line 1, col 1, Some fatal error' file='path/with/backslash/file.js' line='1' SEVERITY='ERROR']"
+      );
+    });
+  });
+
   describe('warning output', function() {
     beforeEach(function() {
       results.push(createDummyWarning());


### PR DESCRIPTION
Fixes #21.

See the issue description.

See also the corresponding PR in the TSLint formatter: https://github.com/ThaNarie/tslint-teamcity-reporter/pull/10