### PR TITLE
Add default ruleId when null

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,7 +1,8 @@
 {
   "extends": "airbnb-base",
   "env": {
-    "node": true
+    "node": true,
+    "mocha": true
   },
   "rules": {
     "arrow-body-style": 0,

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "lint": "eslint .",
-    "prettify": "prettier --write ./**/*.js",
+    "prettify": "prettier --write \"./src/**/*.js\" --write \"./test/**/*.js\"",
     "test": "mocha \"./test/**/*.spec.js\"",
     "test:travis": "nyc npm test && nyc report --reporter=text-lcov | coveralls"
   },

--- a/src/formatters/errors.js
+++ b/src/formatters/errors.js
@@ -15,7 +15,7 @@ module.exports = (results, config) => {
 
   outputList.push(`##teamcity[testSuiteStarted name='${reportName}']`);
 
-  results.forEach(result => {
+  results.forEach((result) => {
     const { messages } = result;
 
     if (messages.length === 0) {
@@ -30,10 +30,12 @@ module.exports = (results, config) => {
     const errorsList = [];
     const warningsList = [];
 
-    messages.forEach(messageObj => {
+    messages.forEach((messageObj) => {
       const { line, column, message, ruleId, fatal, severity } = messageObj;
 
-      const formattedMessage = `line ${line}, col ${column}, ${message} (${ruleId})`;
+      const formattedMessage = `line ${line}, col ${column}, ${message}${
+        ruleId ? ` (${ruleId})` : ''
+      }`;
 
       const isError = fatal || severity === 2;
       if (!isError) {

--- a/src/formatters/inspections.js
+++ b/src/formatters/inspections.js
@@ -13,7 +13,7 @@ module.exports = (results, config) => {
   let errorCount = 0;
   let warningCount = 0;
 
-  results.forEach(result => {
+  results.forEach((result) => {
     const { messages } = result;
 
     if (messages.length === 0) {
@@ -23,21 +23,21 @@ module.exports = (results, config) => {
     const relativeFilePath = path.relative(process.cwd(), result.filePath);
     const filePath = utils.escapeTeamCityString(relativeFilePath.replace(/\\/g, '/')); // Ensure slashes on Windows
 
-    messages.forEach(messageObj => {
+    messages.forEach((messageObj) => {
       const { line, column, message, ruleId, fatal, severity } = messageObj;
       const isError = fatal || severity === 2;
 
+      const escapedRuleId = utils.escapeTeamCityString(ruleId || '<none>');
       const escapedMessage = utils.escapeTeamCityString(message);
-      const escapedRule = utils.escapeTeamCityString(ruleId);
       const formattedMessage = `line ${line}, col ${column}, ${escapedMessage}`;
 
       outputList.push(
-        `##teamcity[inspectionType id='${escapedRule}' category='${reportName}' name='${escapedRule}' description='${reportName}']`
+        `##teamcity[inspectionType id='${escapedRuleId}' category='${reportName}' name='${escapedRuleId}' description='${reportName}']`
       );
 
       const severityLevel = isError ? 'ERROR' : 'WARNING';
       outputList.push(
-        `##teamcity[inspection typeId='${escapedRule}' message='${formattedMessage}' ` +
+        `##teamcity[inspection typeId='${escapedRuleId}' message='${formattedMessage}' ` +
           `file='${filePath}' line='${line}' SEVERITY='${severityLevel}']`
       );
 

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -22,7 +22,7 @@ exports.loadPackageJson = () => {
  * @param {string} str The raw message to display in TeamCity build log.
  * @returns {string} An error message formatted for display in TeamCity
  */
-exports.escapeTeamCityString = str => {
+exports.escapeTeamCityString = (str) => {
   if (!str) {
     return '';
   }

--- a/test/formatter.spec.js
+++ b/test/formatter.spec.js
@@ -1,8 +1,6 @@
-/* global it, context, describe, beforeEach, afterEach */
-
 const sinon = require('sinon');
 const { expect } = require('chai');
-const { createDummyError } = require('./helpers/eslint-factory');
+const { error } = require('./helpers/eslint-factory');
 const utils = require('../src/utils/index');
 const format = require('../src/formatter');
 
@@ -11,7 +9,7 @@ describe('formatter', function () {
     let eslintInput = [];
 
     beforeEach(function () {
-      eslintInput.push(createDummyError());
+      eslintInput.push(error);
     });
 
     afterEach(function () {

--- a/test/formatters/errors.spec.js
+++ b/test/formatters/errors.spec.js
@@ -1,96 +1,90 @@
-/* global it, describe, beforeEach, afterEach */
-
 const { expect } = require('chai');
 const formatErrors = require('../../src/formatters/errors');
-const {
-  createDummyError,
-  createDummyWarning,
-  createFatalError
-} = require('../helpers/eslint-factory');
+const { error, warning, fatalError, unknownError } = require('../helpers/eslint-factory');
 
-describe('error formatting', function() {
+describe('error formatting', function () {
   const reportConfig = {
     reportName: 'ESLint Violations',
     errorStatisticsName: 'ESLintErrorCount',
-    warningStatisticsName: 'ESLintWarningCount'
+    warningStatisticsName: 'ESLintWarningCount',
   };
 
-  let results = [];
-
-  afterEach(function() {
-    results = [];
-  });
-
-  describe('test suite name', function() {
-    it('should include the test suite name header', function() {
-      expect(formatErrors(results, reportConfig)[0]).to.eql(
+  describe('test suite name', function () {
+    it('should include the test suite name header', function () {
+      expect(formatErrors([], reportConfig)[0]).to.eql(
         "##teamcity[testSuiteStarted name='ESLint Violations']"
       );
     });
 
-    it('should include the test suite name footer', function() {
-      expect(formatErrors(results, reportConfig)[1]).to.eql(
+    it('should include the test suite name footer', function () {
+      expect(formatErrors([], reportConfig)[1]).to.eql(
         "##teamcity[testSuiteFinished name='ESLint Violations']"
       );
     });
   });
 
-  describe('fatal error output', function() {
-    beforeEach(function() {
-      results.push(createFatalError());
+  describe('unknown error output', function () {
+    it('omits the ruleId if it is null', function () {
+      const results = [unknownError];
+      expect(formatErrors(results, reportConfig)[1]).to.eql(
+        "##teamcity[testStarted name='ESLint Violations: testfile-unknown.js']"
+      );
+      expect(formatErrors(results, reportConfig)[2]).to.eql(
+        "##teamcity[testFailed name='ESLint Violations: testfile-unknown.js' message='line 1, col 1, Some unknown error']"
+      );
     });
+  });
 
-    it('should include filename at the start of each file test', function() {
+  describe('fatal error output', function () {
+    it('should include filename at the start of each file test', function () {
+      const results = [fatalError];
       expect(formatErrors(results, reportConfig)[1]).to.eql(
         "##teamcity[testStarted name='ESLint Violations: testfile-fatal.js']"
       );
     });
 
-    it('should include all errors within their respective file', function() {
+    it('should include all errors within their respective file', function () {
+      const results = [fatalError];
       expect(formatErrors(results, reportConfig)[2]).to.eql(
         "##teamcity[testFailed name='ESLint Violations: testfile-fatal.js' message='line 1, col 1, Some fatal error (no-eval)']"
       );
     });
 
-    it('should include filename at the end of each file test', function() {
+    it('should include filename at the end of each file test', function () {
+      const results = [fatalError];
       expect(formatErrors(results, reportConfig)[3]).to.eql(
         "##teamcity[testFinished name='ESLint Violations: testfile-fatal.js']"
       );
     });
   });
 
-  describe('error output', function() {
-    beforeEach(function() {
-      results.push(createDummyError());
-    });
-
-    it('should include filename at the start of each file test', function() {
+  describe('error output', function () {
+    it('should include filename at the start of each file test', function () {
+      const results = [error];
       expect(formatErrors(results, reportConfig)[1]).to.eql(
         "##teamcity[testStarted name='ESLint Violations: testfile.js']"
       );
     });
 
-    it('should include all errors within their respective file', function() {
+    it('should include all errors within their respective file', function () {
+      const results = [error];
       expect(formatErrors(results, reportConfig)[2]).to.eql(
         "##teamcity[testFailed name='ESLint Violations: testfile.js' message='line 1, col 1, |'|n|r|x|l|p|||[|] (no-console)|nline 2, col 1, This is a test error. (no-unreachable)']"
       );
     });
 
-    it('should include filename at the end of each file test', function() {
+    it('should include filename at the end of each file test', function () {
+      const results = [error];
       expect(formatErrors(results, reportConfig)[3]).to.eql(
         "##teamcity[testFinished name='ESLint Violations: testfile.js']"
       );
     });
   });
 
-  describe('output with directory paths', function() {
-    beforeEach(function() {
-      results.push({ ...createFatalError(), filePath: 'path\\with\\backslash\\file.js' });
-    });
-
-    it('should render slashes in the service messages', function() {
+  describe('output with directory paths', function () {
+    it('should render slashes in the service messages', function () {
+      const results = [{ ...fatalError, filePath: 'path\\with\\backslash\\file.js' }];
       const outputList = formatErrors(results, reportConfig);
-
       expect(outputList[1]).to.eql(
         "##teamcity[testStarted name='ESLint Violations: path/with/backslash/file.js']"
       );
@@ -100,43 +94,39 @@ describe('error formatting', function() {
     });
   });
 
-  describe('warning output', function() {
-    beforeEach(function() {
-      results.push(createDummyWarning());
-    });
-
-    it('should include filename at the start of each file test', function() {
+  describe('warning output', function () {
+    it('should include filename at the start of each file test', function () {
+      const results = [warning];
       expect(formatErrors(results, reportConfig)[1]).to.eql(
         "##teamcity[testStarted name='ESLint Violations: testfile-warning.js']"
       );
     });
 
-    it('should include all warnings within their respective file', function() {
+    it('should include all warnings within their respective file', function () {
+      const results = [warning];
       expect(formatErrors(results, reportConfig)[2]).to.eql(
         "##teamcity[testStdOut name='ESLint Violations: testfile-warning.js' out='warning: line 1, col 1, Some warning (eqeqeq)|nline 2, col 2, This is a test warning. (complexity)']"
       );
     });
 
-    it('should include filename at the end of each file test', function() {
+    it('should include filename at the end of each file test', function () {
+      const results = [warning];
       expect(formatErrors(results, reportConfig)[3]).to.eql(
         "##teamcity[testFinished name='ESLint Violations: testfile-warning.js']"
       );
     });
   });
 
-  describe('build statistics', function() {
-    beforeEach(function() {
-      results.push(createDummyWarning());
-      results.push(createDummyError());
-    });
-
-    it('should contain total error count', function() {
+  describe('build statistics', function () {
+    it('should contain total error count', function () {
+      const results = [warning, error];
       expect(formatErrors(results, reportConfig)[8]).to.eql(
         "##teamcity[buildStatisticValue key='ESLintErrorCount' value='2']"
       );
     });
 
-    it('should contain total warning count', function() {
+    it('should contain total warning count', function () {
+      const results = [warning, error];
       expect(formatErrors(results, reportConfig)[9]).to.eql(
         "##teamcity[buildStatisticValue key='ESLintWarningCount' value='2']"
       );

--- a/test/formatters/inspections.spec.js
+++ b/test/formatters/inspections.spec.js
@@ -1,39 +1,44 @@
-/* global it, describe, beforeEach, afterEach */
-
 const { expect } = require('chai');
 const formatInspections = require('../../src/formatters/inspections');
-const {
-  createDummyError,
-  createDummyWarning,
-  createFatalError
-} = require('../helpers/eslint-factory');
+const { error, warning, fatalError, unknownError } = require('../helpers/eslint-factory');
 
-describe('inspection formatting', function() {
+describe('inspection formatting', function () {
   const reportConfig = {
     reportName: 'ESLint Violations',
     inspectionCountName: 'ESLintInspectionCount',
     errorStatisticsName: 'ESLintErrorCount',
-    warningStatisticsName: 'ESLintWarningCount'
+    warningStatisticsName: 'ESLintWarningCount',
   };
-  let results = [];
 
-  afterEach(function() {
-    results = [];
-  });
-
-  describe('fatal error output', function() {
-    beforeEach(function() {
-      results.push(createFatalError());
+  describe('unknown error output', function () {
+    it('sets id and name to <none> if ruleId is null', function () {
+      const results = [unknownError];
+      const outputList = formatInspections(results, reportConfig);
+      expect(outputList[0]).to.eql(
+        "##teamcity[inspectionType id='<none>' category='ESLint Violations' name='<none>' description='ESLint Violations']"
+      );
     });
 
-    it('should include the inspection types', function() {
+    it('sets typeId to <none> if ruleId is null', function () {
+      const results = [unknownError];
+      const outputList = formatInspections(results, reportConfig);
+      expect(outputList[1]).to.eql(
+        "##teamcity[inspection typeId='<none>' message='line 1, col 1, Some unknown error' file='testfile-unknown.js' line='1' SEVERITY='ERROR']"
+      );
+    });
+  });
+
+  describe('fatal error output', function () {
+    it('should include the inspection types', function () {
+      const results = [fatalError];
       const outputList = formatInspections(results, reportConfig);
       expect(outputList[0]).to.eql(
         "##teamcity[inspectionType id='no-eval' category='ESLint Violations' name='no-eval' description='ESLint Violations']"
       );
     });
 
-    it('should include the inspections', function() {
+    it('should include the inspections', function () {
+      const results = [fatalError];
       const outputList = formatInspections(results, reportConfig);
       expect(outputList[1]).to.contain(
         "##teamcity[inspection typeId='no-eval' message='line 1, col 1, Some fatal error' file='testfile-fatal.js' line='1' SEVERITY='ERROR']"
@@ -41,12 +46,9 @@ describe('inspection formatting', function() {
     });
   });
 
-  describe('error output', function() {
-    beforeEach(function() {
-      results.push(createDummyError());
-    });
-
-    it('should include the inspection types', function() {
+  describe('error output', function () {
+    it('should include the inspection types', function () {
+      const results = [error];
       const outputList = formatInspections(results, reportConfig);
       expect(outputList[0]).to.eql(
         "##teamcity[inspectionType id='no-console' category='ESLint Violations' name='no-console' description='ESLint Violations']"
@@ -56,7 +58,8 @@ describe('inspection formatting', function() {
       );
     });
 
-    it('should include the inspections', function() {
+    it('should include the inspections', function () {
+      const results = [error];
       const outputList = formatInspections(results, reportConfig);
       expect(outputList[1]).to.eql(
         "##teamcity[inspection typeId='no-console' message='line 1, col 1, |'|n|r|x|l|p|||[|]' file='testfile.js' line='1' SEVERITY='ERROR']"
@@ -67,26 +70,19 @@ describe('inspection formatting', function() {
     });
   });
 
-  describe('output with directory paths', function() {
-    beforeEach(function() {
-      results.push({ ...createFatalError(), filePath: 'path\\with\\backslash\\file.js' });
-    });
-
-    it('should render slashes in the service messages', function() {
+  describe('output with directory paths', function () {
+    it('should render slashes in the service messages', function () {
+      const results = [{ ...fatalError, filePath: 'path\\with\\backslash\\file.js' }];
       const outputList = formatInspections(results, reportConfig);
-
       expect(outputList[1]).to.eql(
         "##teamcity[inspection typeId='no-eval' message='line 1, col 1, Some fatal error' file='path/with/backslash/file.js' line='1' SEVERITY='ERROR']"
       );
     });
   });
 
-  describe('warning output', function() {
-    beforeEach(function() {
-      results.push(createDummyWarning());
-    });
-
-    it('should include the inspection types', function() {
+  describe('warning output', function () {
+    it('should include the inspection types', function () {
+      const results = [warning];
       const outputList = formatInspections(results, reportConfig);
       expect(outputList[0]).to.eql(
         "##teamcity[inspectionType id='eqeqeq' category='ESLint Violations' name='eqeqeq' description='ESLint Violations']"
@@ -96,7 +92,8 @@ describe('inspection formatting', function() {
       );
     });
 
-    it('should include the inspections', function() {
+    it('should include the inspections', function () {
+      const results = [warning];
       const outputList = formatInspections(results, reportConfig);
       expect(outputList[1]).to.eql(
         "##teamcity[inspection typeId='eqeqeq' message='line 1, col 1, Some warning' file='testfile-warning.js' line='1' SEVERITY='WARNING']"
@@ -107,20 +104,17 @@ describe('inspection formatting', function() {
     });
   });
 
-  describe('build statistics', function() {
-    beforeEach(function() {
-      results.push(createDummyWarning());
-      results.push(createDummyError());
-    });
-
-    it('should contain total error count', function() {
+  describe('build statistics', function () {
+    it('should contain total error count', function () {
+      const results = [warning, error];
       const outputList = formatInspections(results, reportConfig);
       expect(outputList[8]).to.eql(
         "##teamcity[buildStatisticValue key='ESLintErrorCount' value='2']"
       );
     });
 
-    it('should contain total warning count', function() {
+    it('should contain total warning count', function () {
+      const results = [warning, error];
       const outputList = formatInspections(results, reportConfig);
       expect(outputList[9]).to.eql(
         "##teamcity[buildStatisticValue key='ESLintWarningCount' value='2']"

--- a/test/helpers/eslint-factory.js
+++ b/test/helpers/eslint-factory.js
@@ -1,52 +1,67 @@
-exports.createFatalError = () => ({
+exports.unknownError = {
+  messages: [
+    {
+      fatal: true, // usually omitted, but will be set to true if there's a parsing error
+      line: 1,
+      column: 1,
+      message: 'Some unknown error',
+      // For example, if the ecmaVersion is set to 5 and ES6+ syntax is used, then ESLint
+      // would fail to parse the file
+      ruleId: null,
+    },
+  ],
+  filePath: 'testfile-unknown.js',
+};
+
+exports.fatalError = {
   messages: [
     {
       fatal: true, // usually omitted, but will be set to true if there's a parsing error
       line: 1,
       column: 1,
       message: 'Some fatal error',
-      ruleId: 'no-eval'
-    }
+      ruleId: 'no-eval',
+    },
   ],
-  filePath: 'testfile-fatal.js'
-});
+  filePath: 'testfile-fatal.js',
+};
 
-exports.createDummyError = () => ({
+exports.error = {
   messages: [
     {
       severity: 2, // error
       line: 1,
       column: 1,
       message: "'\n\r\u0085\u2028\u2029|[]",
-      ruleId: 'no-console'
+      ruleId: 'no-console',
     },
     {
       severity: 2, // error
       line: 2,
       column: 1,
       message: 'This is a test error.',
-      ruleId: 'no-unreachable'
-    }
+      ruleId: 'no-unreachable',
+    },
   ],
-  filePath: 'testfile.js'
-});
+  filePath: 'testfile.js',
+};
 
-exports.createDummyWarning = () => ({
+exports.warning = {
   messages: [
     {
       severity: 1, // warning
       line: 1,
       column: 1,
       message: 'Some warning',
-      ruleId: 'eqeqeq'
+      ruleId: 'eqeqeq',
     },
     {
       severity: 1, // warning
       line: 2,
       column: 2,
       message: 'This is a test warning.',
-      ruleId: 'complexity'
-    }
+      ruleId: 'complexity',
+    },
   ],
-  filePath: 'testfile-warning.js'
-});
+  filePath: 'testfile-warning.js',
+};

--- a/test/smoke.spec.js
+++ b/test/smoke.spec.js
@@ -1,10 +1,8 @@
-/* global it, describe, beforeEach, afterEach */
-
 const { expect } = require('chai');
 const sh = require('shelljs');
 const path = require('path');
 const fs = require('fs-extra');
-const { createDummyError } = require('./helpers/eslint-factory');
+const { error } = require('./helpers/eslint-factory');
 
 const basePath = path.resolve(__dirname, '..');
 const pathToTestJson = path.resolve(__dirname, 'result.json');
@@ -15,7 +13,7 @@ describe('smoke tests', function () {
     let esLintOutput = [];
 
     beforeEach(function () {
-      esLintOutput.push(createDummyError());
+      esLintOutput.push(error);
     });
 
     afterEach(function () {

--- a/test/utils/index.spec.js
+++ b/test/utils/index.spec.js
@@ -1,22 +1,20 @@
-/* global it, describe, context */
-
 const fs = require('fs');
 const { expect } = require('chai');
 const sinon = require('sinon');
 const utils = require('../../src/utils');
 
-describe('utils', function() {
+describe('utils', function () {
   describe('loadPackageJson', () => {
-    context('success', function() {
-      it('returns a string representation of package.json', function() {
+    context('success', function () {
+      it('returns a string representation of package.json', function () {
         sinon.stub(fs, 'readFileSync').callsFake(() => 'package.json contents');
         expect(utils.loadPackageJson()).to.eql('package.json contents');
         fs.readFileSync.restore();
       });
     });
 
-    context('failure', function() {
-      it('returns an empty object representation', function() {
+    context('failure', function () {
+      it('returns an empty object representation', function () {
         sinon.stub(fs, 'readFileSync').throws();
         expect(utils.loadPackageJson()).to.eql('{}');
         fs.readFileSync.restore();
@@ -24,12 +22,12 @@ describe('utils', function() {
     });
   });
 
-  describe('escapeTeamCityString', function() {
-    it('returns empty strings', function() {
+  describe('escapeTeamCityString', function () {
+    it('returns empty strings', function () {
       expect(utils.escapeTeamCityString(null)).to.eql('');
     });
 
-    it('replaces TeamCity special characters', function() {
+    it('replaces TeamCity special characters', function () {
       expect(utils.escapeTeamCityString("'\n\r\u0085\u2028\u2029|[]")).to.eql("|'|n|r|x|l|p|||[|]");
     });
   });


### PR DESCRIPTION
## Desription
Sometimes ESLint does not always provide a ruleId in the message
objects. This can happen if, for example, you have your ecmaVersion
set to 5 but are using ES6+ features. ESLint would fail to parse
the syntax and return a fatal error. A ruleId would not be able
to be assigned as it would be unable to match on anything.

This is problematic, especially for the inspections formatter as
TeamCity complains if an inspection is returned without an id or
typeId.

This PR addresses this by using a default of '<none>' of no ruleId
is found.

Fixes: #75 